### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 This package is "go-gettable", just do:
 
-    go get github.com/AlexanderChen1989/rest
+    go get github.com/AlexanderChen1989/go-json-rest/rest
 
 
 ## Vendoring


### PR DESCRIPTION
Fix path issue when go get in README.md.

github.com/AlexanderChen1989/rest -> github.com/AlexanderChen1989/go-json-rest/rest
